### PR TITLE
Fix Neovim background to match theme base color

### DIFF
--- a/neovim.lua
+++ b/neovim.lua
@@ -6,6 +6,8 @@ return {
         filter = "ristretto",
         override = function()
           return {
+            Normal = { bg = "#1c0e00" },
+            NormalNC = { bg = "#1c0e00" },
             NonText = { fg = "#948a8b" },
             MiniIconsGrey = { fg = "#948a8b" },
 	    MiniIconsRed = { fg = "#fd6883" },


### PR DESCRIPTION
## Summary

  This PR aligns Neovim’s main background with the theme background defined in colors.toml.

  ## What Changed

  - Updated neovim.lua overrides to set:
      - Normal.bg = "#1c0e00"
      - NormalNC.bg = "#1c0e00"

  ## Why

  The theme background is background = "#1c0e00" in colors.toml.
  Neovim was using monokai-pro (ristretto) defaults, which could diverge from the theme’s core background color. This
  change keeps Neovim visually consistent with the rest of the theme.

  ## Scope

  - File changed: neovim.lua